### PR TITLE
IPへのログイン要求リクエストのリダイレクト対応

### DIFF
--- a/src/main/java/org/montsuqi/monsiaj/client/OpenIdConnect.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/OpenIdConnect.java
@@ -103,6 +103,8 @@ public class OpenIdConnect {
       params.put("redirect_uri", redirect_uri);
       params.put("nonce", nonce);
       JSONObject res = request(authentication_request_uri, "POST", params);
+      String redirect_uri = res.getJSONObject("header").getString("Location");
+      res = request(redirect_uri, "POST", params);
       this.request_url = res.getString("request_url");
     }
 


### PR DESCRIPTION
IPへのログイン要求リクエストにいったんリダイレクトが挟まれるとのことなので、その対応です。
POSTでのアクセスのため HttpURLConnection の `setInstanceFollowRedirects(true)` は使用せず、単にリクエストを1回増やす対応としています。