### PR TITLE
macOSでランチャーでLookAndFeelを変更した場合にnull pointer exceptionが発生しうまく動作しない場合があった。

### DIFF
--- a/src/main/java/org/montsuqi/monsiaj/client/ConfigPanel.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/ConfigPanel.java
@@ -227,17 +227,6 @@ public class ConfigPanel extends JPanel {
             } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | UnsupportedLookAndFeelException e) {
                 logger.warn(e);
             }
-            SwingUtilities.invokeLater(() -> {
-                Component root = SwingUtilities.getRoot(basicPanel);
-                try {
-                    if (root != null) {
-                        SwingUtilities.updateComponentTreeUI(root);
-                    }
-
-                } catch (Exception e) {
-                    logger.catching(Level.WARN, e);
-                }
-            });
         }
     }
 


### PR DESCRIPTION
LookAndFeel変更時にランチャーダイアログのLAFをその場で変更しないようにした。
(サーバ接続後の画面にはLAFが適用される。)