### PR TITLE
オンプレでクライアント保存で401 Unauthorizedになるのを修正

### DIFF
--- a/src/main/java/org/montsuqi/monsiaj/client/Protocol.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/Protocol.java
@@ -207,6 +207,9 @@ public class Protocol {
                 ((HttpsURLConnection) con).setSSLSocketFactory(sslSocketFactory);
             }
         }
+        if (!serverType.equals("ginbee")) {
+            setAuthHeader(con);
+        }
         return con;
     }
 


### PR DESCRIPTION
オンプレでの接続でGetBLOB、PostBLOBにAuthヘッダがついていなかった。