### PR TITLE
ginbeeではJSONRPC get_messageを呼ばないよう修正

### DIFF
--- a/src/main/java/org/montsuqi/monsiaj/client/Client.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/Client.java
@@ -368,7 +368,9 @@ public class Client {
                 if (!protocol.enablePushClient()) {
                     listDownloads();
                 }
-                getMessage();
+                if (!this.protocol.getServerType().equals("ginbee")) {
+                    getMessage();
+                }
                 stopReceiving();
             }
         } catch (IOException | JSONException ex) {

--- a/src/main/java/org/montsuqi/monsiaj/client/Protocol.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/Protocol.java
@@ -51,6 +51,13 @@ import org.json.JSONObject;
  */
 public class Protocol {
 
+    /**
+     * @return the serverType
+     */
+    public String getServerType() {
+        return serverType;
+    }
+
     static final Logger logger = LogManager.getLogger(Protocol.class);
     // jsonrpc
     private int rpcId;
@@ -303,7 +310,7 @@ public class Protocol {
         }
         HttpURLConnection con = getHttpURLConnection(url);
         if (!useSSO) {
-            switch (serverType) {
+            switch (getServerType()) {
                 case "ginbee":
                     if (method.equals("start_session")) {
                         setAuthHeader(con);
@@ -509,7 +516,7 @@ public class Protocol {
 
         logger.info("protocol_version:" + this.protocolVersion);
         logger.info("application_version:" + this.applicationVersion);
-        logger.info("server_type:" + this.serverType);
+        logger.info("server_type:" + this.getServerType());
     }
 
     public synchronized JSONArray listDownloads() throws IOException, JSONException {


### PR DESCRIPTION
ginbeeではJSONRPC get_messageを実行しないよう修正した。
get_messageはVPN回線のkeep-alive用に使用していたが、現在はwebsocketでkeep-aliveしているので不要