### PR TITLE
Java 8で動作するようString.strip()をString.trim()に変更

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.montsuqi.monsiaj</groupId>
     <artifactId>monsiaj</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.17</version>
+    <version>2.0.18</version>
     <name>monsiaj</name>
     <url>https://github.com/montsuqi/monsiaj</url>
     <description>montsuqi panda client for java</description>

--- a/src/main/java/org/montsuqi/monsiaj/client/ConfigPanel.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/ConfigPanel.java
@@ -273,7 +273,7 @@ public class ConfigPanel extends JPanel {
         // since setPass fetches its value from the preferences internally.
         conf.setSavePassword(num, savePasswordCheckbox.isSelected());
         String password = new String(passwordEntry.getPassword());
-        conf.setPassword(num, password.strip());
+        conf.setPassword(num, password.trim());
         conf.setAuthURI(num, authURIEntry.getText());
         conf.setUseSSO(num, useSSOCheckbox.isSelected());
 
@@ -282,7 +282,7 @@ public class ConfigPanel extends JPanel {
         conf.setCACertificateFile(num, caCertificateEntry.getText());
         conf.setClientCertificateFile(num, clientCertificateEntry.getText());
         String exportPassword = new String(exportPasswordEntry.getPassword());
-        conf.setClientCertificatePassword(num, exportPassword.strip());
+        conf.setClientCertificatePassword(num, exportPassword.trim());
         conf.setSaveClientCertificatePassword(num, saveClientCertificatePasswordCheckbox.isSelected());
         conf.setUsePKCS11(num, usePKCS11Checkbox.isSelected());
         conf.setPKCS11Lib(num, pkcs11LibEntry.getText());


### PR DESCRIPTION
Java 11の環境では問題ないがJava 8の環境ではString.strip()でエラーが発生しうまく動作しなかった。
String.strip()はJava 11からサポートのため、String.strip()はString.trim()のUnicode強化版とのことなので、今回除外したいのはASCIIの改行コードと空白なのでtrim()でも問題ない。

参考
https://codeday.me/jp/qa/20190309/383626.html