### PR TITLE
システムプロパティにmonsia.disable.panda_htmlを追加

### DIFF
--- a/src/main/java/org/montsuqi/monsiaj/widgets/PandaHTML.java
+++ b/src/main/java/org/montsuqi/monsiaj/widgets/PandaHTML.java
@@ -43,8 +43,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * <p>A HTML viewer for platforms other than MacOS X.</p> <p>This component uses
- * JEditorPane to render HTML.</p>
+ * <p>
+ * A HTML viewer for platforms other than MacOS X.</p>
+ * <p>
+ * This component uses JEditorPane to render HTML.</p>
  */
 public class PandaHTML extends JPanel {
 
@@ -90,19 +92,23 @@ public class PandaHTML extends JPanel {
     }
 
     /**
-     * <p>Loads a HTML from the given URL and render it.</p>
+     * <p>
+     * Loads a HTML from the given URL and render it.</p>
      *
      * @param uri source URL of the document.
      */
     public void setURI(URL uri) {
+        if (System.getProperty("monsia.disable.panda_html") != null) {
+            return;
+        }
         Runnable loader = createLoader(uri);
-        logger.debug("loading: {0}", uri); 
+        logger.debug("loading: {0}", uri);
         Executor executor = new ThreadPerTaskExecutor();
         executor.execute(loader);
     }
-    
+
     public void setText(String text) {
-        ((JEditorPane)html).setText(text);
+        ((JEditorPane) html).setText(text);
     }
 
     protected class ThreadPerTaskExecutor implements Executor {
@@ -136,5 +142,5 @@ public class PandaHTML extends JPanel {
         f.pack();
         f.setSize(400, 600);
         f.validate();
-    }    
+    }
 }


### PR DESCRIPTION
日レセシステム管理の設定でクライアント接続時のマスターメニュー下部に任意のURLのWebページを表示する機能がある(PandaHTMLウィジェット)。
SSLクライアント認証を有効にして、URLにhttpsのページを指定した場合、SSLタブのCA証明書ファイルにURLのCA証明書が通常含まれないのでPandaHTML内でセキュリティエラーとなりエラーダイアログがでてクライアントが終了する。
マスターメニューのURL設定はマスターメニューの先にあるため、一度エラーとなるhttpsを設定してしまうと日レセクライアントからでは変更できくなる。

PandaHTMLでのセキュリティエラーを無視できればいいのだが単純にtry catchでくくっただけでは駄目だった。

ひとまずPandaHTMLの動作を無効にするシステムプロパティを追加する。
(glcient2にも同様の環境変数がある。)