### PR TITLE
不要なSSLContext.setDefaultの削除

### DIFF
--- a/src/main/java/org/montsuqi/monsiaj/client/SSLSocketFactoryHelper.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/SSLSocketFactoryHelper.java
@@ -143,7 +143,6 @@ public class SSLSocketFactoryHelper {
         ctx = SSLContext.getInstance("TLSv1.2");
         ctx.init(keyManagers, trustManagers, null);
         factory = ctx.getSocketFactory();
-        SSLContext.setDefault(ctx);
         return factory;
     }
 
@@ -159,7 +158,6 @@ public class SSLSocketFactoryHelper {
         trustManagers = createCAFileTrustManagers(caCert);
         ctx.init(keyManagers, trustManagers, null);
         factory = ctx.getSocketFactory();
-        SSLContext.setDefault(ctx);
         return factory;
     }
 


### PR DESCRIPTION
#193 の関連修正

SSLContext.setDefaultは不要だった。かつSSLクライアント認証のCA証明書のみをストアに設定し、市販の証明書を使ったhttpsユーザページ表示時にサーバ証明書エラーを誘発する。

当初、HttpURLConnectionのDefaultにSSLSocketFactoryを設定していたので必要だったかもしれないが、最近の修正でHttpURLConnectionのインスタンスに個別にSSLSocketFactoryを設定するようになったのでもう不要になった。