### PR TITLE
VPN経由(sms-*.orca.orcamo.jp)のときのみNO_PROXYを設定するよう変更

### DIFF
--- a/src/main/java/org/montsuqi/monsiaj/client/Protocol.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/Protocol.java
@@ -76,7 +76,7 @@ public class Protocol {
     private String protocolVersion;
     private String applicationVersion;
     private String serverType;
-    private boolean noProxy;
+    private boolean forceNoProxy;
 
     private int totalExecTime;
     private int appExecTime;
@@ -118,10 +118,14 @@ public class Protocol {
         this.serverType = "";
         /* VPN経由のみNO_PROXYを設定する */
         if (authURI.contains("sms.orca.orcamo.jp") || authURI.contains("sms-stg.orca.orcamo.jp")) {
-            noProxy = true;
+            forceNoProxy = true;
         } else {
-            noProxy = false;
+            forceNoProxy = false;
         }
+        logger.info("forceNoProxy:" + forceNoProxy);
+        logger.info("proxyHost:" + System.getProperty("proxyHost"));
+        logger.info("proxyPort:" + System.getProperty("proxyPort"));
+        logger.info("nonProxyHosts:" + System.getProperty("nonProxyHosts"));        
     }
 
     public boolean enablePushClient() {
@@ -213,7 +217,7 @@ public class Protocol {
 
     private HttpURLConnection getHttpURLConnection(URL url) throws IOException {
         HttpURLConnection con;
-        if (noProxy) {
+        if (forceNoProxy) {
             con = (HttpURLConnection) url.openConnection(Proxy.NO_PROXY);
         } else {
             con = (HttpURLConnection) url.openConnection();

--- a/src/main/java/org/montsuqi/monsiaj/client/Protocol.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/Protocol.java
@@ -76,6 +76,7 @@ public class Protocol {
     private String protocolVersion;
     private String applicationVersion;
     private String serverType;
+    private boolean noProxy;
 
     private int totalExecTime;
     private int appExecTime;
@@ -115,6 +116,12 @@ public class Protocol {
         this.startupMessage = null;
         this.useSSO = useSSO;
         this.serverType = "";
+        /* VPN経由のみNO_PROXYを設定する */
+        if (authURI.contains("sms.orca.orcamo.jp") || authURI.contains("sms-stg.orca.orcamo.jp")) {
+            noProxy = true;
+        } else {
+            noProxy = false;
+        }
     }
 
     public boolean enablePushClient() {
@@ -205,8 +212,12 @@ public class Protocol {
     }
 
     private HttpURLConnection getHttpURLConnection(URL url) throws IOException {
-        HttpURLConnection con = (HttpURLConnection) url.openConnection(Proxy.NO_PROXY);
-
+        HttpURLConnection con;
+        if (noProxy) {
+            con = (HttpURLConnection) url.openConnection(Proxy.NO_PROXY);
+        } else {
+            con = (HttpURLConnection) url.openConnection();
+        }
         if (url.getProtocol().equals("https")) {
             if (sslSocketFactory != null) {
                 ((HttpsURLConnection) con).setSSLSocketFactory(sslSocketFactory);


### PR DESCRIPTION
* monsiajプロキシ仕様
    * 現行仕様
        * 日レセ操作用のJSONRPCのHTTPクライアントにはNO_PROXY=*を設定しプロキシ利用できないように設定
        * VPNの場合にお知らせページ https://www.orca.med.or.jp/info/ を表示するのにプロキシ設定が必要だがプロキシ設定するとプロキシ経由で日レセサーバに接続することになり日レセサーバに接続できない場合があるため
        * WAF(TLS1.2のみのインターネット接続)の場合、VPNではないので基本プロキシ設定はいらないが、クライアント側の都合でプロキシを経由する場合、前述のNO_PROXY設定のため日レセサーバにアクセスできない
        * -> NO_PROXY設定を単純に解除すると現行のVPNユーザが日レセサーバに接続できない可能性がある
    * 修正案
        * AUTH_URIがsms-*.orca.orcamo.jpの場合のみJSONRPC HTTPクライアントにNO_PROXYを設定する