### PR TITLE
ログファイル削除が常に実行される

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.montsuqi.monsiaj</groupId>
     <artifactId>monsiaj</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.19</version>
+    <version>2.0.20</version>
     <name>monsiaj</name>
     <url>https://github.com/montsuqi/monsiaj</url>
     <description>montsuqi panda client for java</description>

--- a/src/main/java/org/montsuqi/monsiaj/util/LogFile.java
+++ b/src/main/java/org/montsuqi/monsiaj/util/LogFile.java
@@ -13,7 +13,7 @@ import java.io.File;
  */
 public class LogFile {
 
-    private static final long VALID_PERIOD = 90 * 24 * 3600 * 1000L; /* 30days millisec */
+    private static final long VALID_PERIOD = 90 * 24 * 3600 * 1000L; /* 90days millisec */
     public final static File LOG_DIR;
 
     static {

--- a/src/main/java/org/montsuqi/monsiaj/util/LogFile.java
+++ b/src/main/java/org/montsuqi/monsiaj/util/LogFile.java
@@ -13,7 +13,7 @@ import java.io.File;
  */
 public class LogFile {
 
-    private static final long VALID_PERIOD = 30 * 24 * 3600 * 1000L; /* 30days millisec */
+    private static final long VALID_PERIOD = 90 * 24 * 3600 * 1000L; /* 30days millisec */
     public final static File LOG_DIR;
 
     static {

--- a/src/main/java/org/montsuqi/monsiaj/util/LogFile.java
+++ b/src/main/java/org/montsuqi/monsiaj/util/LogFile.java
@@ -13,7 +13,7 @@ import java.io.File;
  */
 public class LogFile {
 
-    private static final long VALID_TERM = 30 * 24 * 3600 * 1000L; /* 30days millisec */
+    private static final long VALID_PERIOD = 30 * 24 * 3600 * 1000L; /* 30days millisec */
     public final static File LOG_DIR;
 
     static {
@@ -26,7 +26,7 @@ public class LogFile {
         for (File f : LOG_DIR.listFiles()) {
             try {
                 long elaps = now - f.lastModified();
-                if (elaps > VALID_TERM) {
+                if (elaps > VALID_PERIOD) {
                     if (f.isFile()) {
                         f.delete();
                     }

--- a/src/main/java/org/montsuqi/monsiaj/util/LogFile.java
+++ b/src/main/java/org/montsuqi/monsiaj/util/LogFile.java
@@ -13,7 +13,7 @@ import java.io.File;
  */
 public class LogFile {
 
-    private static final long VALID_TERM = 30 * 24 * 3600 * 1000; /* 30days millisec */
+    private static final long VALID_TERM = 30 * 24 * 3600 * 1000L; /* 30days millisec */
     public final static File LOG_DIR;
 
     static {

--- a/src/main/java/org/montsuqi/monsiaj/util/TempFile.java
+++ b/src/main/java/org/montsuqi/monsiaj/util/TempFile.java
@@ -14,7 +14,7 @@ import java.util.UUID;
  */
 public class TempFile {
 
-    private final static long VALID_PERIOD = 24 * 3600 * 1000; /* 1day millisec */
+    private final static long VALID_PERIOD = 24 * 3600 * 1000L; /* 1day millisec */
     public final static File TEMP_DIR_ROOT;
     public final static File TEMP_DIR;
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -11,7 +11,7 @@ and open the template in the editor.
     <appenders>
         <File
             name="File"
-            fileName="${sys:user.home}/.monsiaj/logs/monsiaj.log.${date:yyyyMMddhhmmssSS}.txt"
+            fileName="${sys:user.home}/.monsiaj/logs/monsiaj.log.${date:yyyyMMddHHmmssSS}.txt"
         >
             <PatternLayout
                 pattern="%d{MM/dd HH:mm:ss} [%-5p] %m%n%ex"


### PR DESCRIPTION
ctimeの経過時間で削除するためのしきい値が即値計算の際にint型となりオーバーフローし負値となっていた。
そのため作成直後のログファイルも削除されログが書き込まれない状態となった。