### PR TITLE
#194の影響でSSO接続できなくなっていた

### DIFF
--- a/src/main/java/org/montsuqi/monsiaj/client/OpenIdConnect.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/OpenIdConnect.java
@@ -33,6 +33,7 @@ class HttpResponseException extends IOException {
 public class OpenIdConnect {
 
     static final Logger logger = LogManager.getLogger(OpenIdConnect.class);
+    private final Protocol protocol;
     private final String sso_sp_uri;
     private final JSONObject sso_sp_params;
     private final String sso_user;
@@ -49,7 +50,8 @@ public class OpenIdConnect {
     private String ip_cookie = "";
     private String ip_domain = "";
 
-    public OpenIdConnect(String sso_user, String sso_password, String sso_sp_uri, JSONObject sso_sp_params) throws IOException {
+    public OpenIdConnect(Protocol protocol, String sso_user, String sso_password, String sso_sp_uri, JSONObject sso_sp_params) throws IOException {
+        this.protocol = protocol;
         this.sso_sp_uri = sso_sp_uri;
         this.sso_user = sso_user;
         this.sso_password = sso_password;
@@ -130,8 +132,7 @@ public class OpenIdConnect {
     }
 
     private JSONObject request(String uri, RequestOption option) throws IOException {
-        URL url = new URL(uri);
-        HttpURLConnection con = (HttpURLConnection) url.openConnection(Proxy.NO_PROXY);
+        HttpURLConnection con = (HttpURLConnection) protocol.getHttpURLConnection(uri);
         con.setInstanceFollowRedirects(false);
         con.setRequestProperty("Accept", "application/json");
         con.setRequestProperty("X-Support-SSO", "1");
@@ -147,7 +148,7 @@ public class OpenIdConnect {
             con.setDoOutput(true);
             con.setRequestMethod("POST");
             con.setRequestProperty("Content-Type", "application/json");
-            try (OutputStreamWriter osw = new OutputStreamWriter(con.getOutputStream(), "UTF-8")) {
+            try ( OutputStreamWriter osw = new OutputStreamWriter(con.getOutputStream(), "UTF-8")) {
                 if (option.params != null) {
                     osw.write(option.params.toString());
                 }

--- a/src/main/java/org/montsuqi/monsiaj/client/Protocol.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/Protocol.java
@@ -210,12 +210,12 @@ public class Protocol {
         this.sslType = TYPE_SSL_PKCS11;
     }
 
-    private HttpURLConnection getHttpURLConnection(String strURL) throws IOException {
+    public HttpURLConnection getHttpURLConnection(String strURL) throws IOException {
         URL url = new URL(strURL);
         return getHttpURLConnection(url);
     }
 
-    private HttpURLConnection getHttpURLConnection(URL url) throws IOException {
+    public HttpURLConnection getHttpURLConnection(URL url) throws IOException {
         HttpURLConnection con;
         if (forceNoProxy) {
             con = (HttpURLConnection) url.openConnection(Proxy.NO_PROXY);
@@ -420,7 +420,7 @@ public class Protocol {
     }
 
     private String startOpenIDConnect(String sso_user, String sso_password, String sso_sp_uri, JSONObject params) throws IOException, JSONException {
-        OpenIdConnect sso = new OpenIdConnect(sso_user, sso_password, authURI, params);
+        OpenIdConnect sso = new OpenIdConnect(this, sso_user, sso_password, authURI, params);
         return sso.connect();
     }
 


### PR DESCRIPTION
protocol.getHttpURLConnection(uri)を使うよう修正。

* 通常認証、SSO認証ができることを確認