### PR TITLE
自動更新版(monsiaj-loader-x.x.x.jar)の有償化対応

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.montsuqi.monsiaj</groupId>
     <artifactId>monsiaj</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.22</version>
+    <version>2.0.23</version>
     <name>monsiaj</name>
     <url>https://github.com/montsuqi/monsiaj</url>
     <description>montsuqi panda client for java</description>

--- a/src/main/java/org/montsuqi/monsiaj/client/Launcher.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/Launcher.java
@@ -63,7 +63,6 @@ import org.montsuqi.monsiaj.util.OptionParser;
 import org.montsuqi.monsiaj.util.SystemEnvironment;
 import org.montsuqi.monsiaj.util.TempFile;
 import org.montsuqi.monsiaj.widgets.Button;
-import org.montsuqi.monsiaj.widgets.ExceptionDialog;
 
 public class Launcher {
 

--- a/src/main/java/org/montsuqi/monsiaj/loader/Loader.java
+++ b/src/main/java/org/montsuqi/monsiaj/loader/Loader.java
@@ -302,6 +302,8 @@ public class Loader {
                 setOrcaId(orcaId);
                 if (saveAccessKey) {
                     setAccessKey(accessKey);
+                } else {
+                    setAccessKey(null);
                 }
                 return version;
             } catch (UnAuthorized ex) {
@@ -360,9 +362,12 @@ public class Loader {
         Method m = cobj.getMethod("main", new Class[]{args.getClass()});
         m.setAccessible(true);
         int mods = m.getModifiers();
-        if (m.getReturnType() != void.class || !Modifier.isStatic(mods)
+
+        if (m.getReturnType() != void.class
+                || !Modifier.isStatic(mods)
                 || !Modifier.isPublic(mods)) {
-            throw new NoSuchMethodException("main");
+            throw new NoSuchMethodException(
+                    "main");
         }
         m.invoke(null, new Object[]{args});
     }

--- a/src/main/java/org/montsuqi/monsiaj/loader/Loader.java
+++ b/src/main/java/org/montsuqi/monsiaj/loader/Loader.java
@@ -86,10 +86,6 @@ public class Loader {
         }
     }
 
-    private void removeProperty(String key) {
-        setProperty(key, null);
-    }
-
     private void setProperty(String key, String value) {
         if (value == null) {
             prop.remove(key);
@@ -254,10 +250,15 @@ public class Loader {
         // 初回だけアクセスキーを設定ファイルから読み込む
         if (n == 0) {
             orcaId = getOrcaId();
-            accessKey = getAccessKey();
             saveAccessKey = getSaveAccessKey();
-            if (!accessKey.isEmpty()) {
-                return;
+            if (saveAccessKey) {
+                accessKey = getAccessKey();
+                if (!accessKey.isEmpty()) {
+                    return;
+                }
+            } else {
+                accessKey = "";
+                setAccessKey(null);
             }
         }
         JTextField id = new JTextField(orcaId);
@@ -301,8 +302,6 @@ public class Loader {
                 setOrcaId(orcaId);
                 if (saveAccessKey) {
                     setAccessKey(accessKey);
-                } else {
-                    setAccessKey(null);
                 }
                 return version;
             } catch (UnAuthorized ex) {


### PR DESCRIPTION
## 背景

* 日レセ有償化に伴い、monsiajの配布元をベーシック認証がかかったhttpsサーバに移動する
    * https://dl.orca.med.or.jp
* ベーシック認証がかかっているためユーザ、パスワード(医療機関ID、アクセスキー)を入力してもらう必要がある

## 仕様

* 動作自体は有償化対応以前の動きをほぼ踏襲
    * サーバに最新版バージョンを問い合わせ、手元のバージョンと差異があればダウンロードしてキャッシュ保存
    * キャッシュから起動
* デフォルトのバージョン取得URLとパッケージ取得URLが変わるので設定ファイルをloader.propertiesからloader2.propertiesに変更して初期化して作り直す
* 最新バージョン問い合わせ時にユーザ、パスワードを設定ファイルまたはダイアログから取得して認証設定する
    * 最初に設定ファイルを読込、ID、アクセスキーがあればそれを設定して接続、失敗もしくは設定がない場合はダイアログを表示して入力を促す
    * あわせて5回認証失敗したら終了する
    * 認証に成功し、ダイアログの「アクセスキーを保存」にチェックがある場合に設定ファイルにID、アクセスキーを保存する

## 動作確認

* 正しいID、アクセスキーを入力した場合に最新版ダウンロードして起動すること
    * アクセスキーを保存にチェックした場合、次回起動からはダイアログ表示なしで最新版チェック&起動が動作すること
    * アクセスキーを保存にチェックしなかった場合、再度ダイアログが表示されること
* 誤ったID、アクセスキーを入力した場合、5回目もしくは4回目まではダイアログ表示され、それでも失敗すると規定回数到達エラーが表示されること

## 課題

* アクセスキーを平文保存しているのを対策する
    * [簡易対応]固定鍵で共通鍵暗号する
    * OSのキーストアに保存する(毎回、実行時にOSユーザ認証が必要になる)