### PR TITLE
WebSocket再接続後のPingがうまく動作せず回線の無通信時間制限にかかり再接続を繰り返す不具合

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.montsuqi.monsiaj</groupId>
     <artifactId>monsiaj</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.23</version>
+    <version>2.0.25</version>
     <name>monsiaj</name>
     <url>https://github.com/montsuqi/monsiaj</url>
     <description>montsuqi panda client for java</description>
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>org.glassfish.tyrus.bundles</groupId>
             <artifactId>tyrus-standalone-client</artifactId>
-            <version>1.13</version>
+            <version>1.13.1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.json/json -->
         <dependency>

--- a/src/main/java/org/montsuqi/monsiaj/client/PushReceiver.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/PushReceiver.java
@@ -48,7 +48,7 @@ public class PushReceiver implements Runnable {
 
     static final long RECONNECT_WAIT_INIT = 1L;
     static final long RECONNECT_WAIT_MAX = 600L;
-    static final long IDLE_TIMEOUT = 30*1000L;
+    static final long IDLE_TIMEOUT = 30 * 1000L;
     static final long PING_TIMEOUT = 30L;
     static final long PING_INTERVAL = 10L;
 
@@ -59,7 +59,7 @@ public class PushReceiver implements Runnable {
     private boolean connWarned;
     private Session session;
     private ClientManager client;
-    private ScheduledExecutorService executorService;
+    private ScheduledExecutorService executorService = null;
     private Instant lastPong;
     private long reconnectWait;
 
@@ -281,7 +281,10 @@ public class PushReceiver implements Runnable {
             LOGGER.info("---- onError\n" + th.toString());
             lastPong = null;
             warnDisconnect();
-            executorService.shutdownNow();
+            if (executorService != null) {
+                executorService.shutdownNow();
+                executorService = null;
+            }
         }
 
         @OnClose
@@ -289,7 +292,10 @@ public class PushReceiver implements Runnable {
             LOGGER.info("---- onClose");
             lastPong = null;
             warnDisconnect();
-            executorService.shutdown();
+            if (executorService != null) {
+                executorService.shutdownNow();
+                executorService = null;
+            }
         }
     }
 }


### PR DESCRIPTION
### 現象

一度回線が切れると30秒毎に切断と再接続を繰り返す。

### 原因

ExecutorServiceによる10秒間隔のPingの送信処理の挿入位置が悪かったため、初回接続時のみPing送信が有効で、再接続した後はおそらく古い切断済みのSessionでPingを送信するためにMaxIdleTimeout=30sとなりonClose処理が走っていたと考えられる。

### 修正

onOpenでExecutorServiceを登録実行する、onCloseでExecutorServiceを停止するよう修正した。

### 動作確認

* GAM(SoftwareVPN)とWAF(TLS1.2、インターネット接続)のそれぞれで意図的に回線切断し、再接続を行ない、PingPong通信が動作すること、切断、再接続を繰り返さないことを確認した。