### PR TITLE
証明書自動更新機能修正

### DIFF
--- a/src/main/java/org/montsuqi/monsiaj/client/CertificateManager.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/CertificateManager.java
@@ -1,27 +1,22 @@
 package org.montsuqi.monsiaj.client;
 
-import org.montsuqi.monsiaj.util.Messages;
 import java.io.*;
-import java.net.Authenticator;
 import java.net.HttpURLConnection;
-import java.net.PasswordAuthentication;
 import java.net.URL;
 import java.net.Proxy;
 import java.security.cert.X509Certificate;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.TimeZone;
 import javax.net.ssl.*;
-import javax.swing.JOptionPane;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
@@ -39,9 +34,24 @@ public class CertificateManager {
     private Calendar notAfter;
     public static final int CERT_EXPIRE_CHECK_MONTHES = 2;
 
+    private static final Map<String, String> AUTH_HOST_MAP = new HashMap<String, String>() {
+        {
+            // 運用環境
+            put("sms.orca.orcamo.jp", "auth.cmo.orcamo.jp");
+            put("sms.glorca.orcamo.jp", "auth.glcmo.orcamo.jp");
+            // ステージング環境
+            put("sms-stg.orca.orcamo.jp", "auth-stg.cmo.orcamo.jp");
+            put("sms-stg.glorca.orcamo.jp", "auth-stg.glcmo.orcamo.jp");
+            // テスト環境
+            put("sms-test.orca.orcamo.jp", "auth-test.cmo.orcamo.jp");
+            // デモ環境
+            put("sms.orca-ng.org", "auth.orca-ng.org");
+        }
+    };
+
     public CertificateManager(String fileName, String pass) throws IOException, GeneralSecurityException {
-      this.fileName = fileName;
-      this.password = pass;
+        this.fileName = fileName;
+        this.password = pass;
     }
 
     public boolean isExpire() throws SSLException, FileNotFoundException, IOException, GeneralSecurityException {
@@ -51,7 +61,7 @@ public class CertificateManager {
         Calendar notAfter = getNotAfter();
         Calendar checkDate = Calendar.getInstance();
         checkDate.setTimeZone(TimeZone.getDefault());
-        return(checkDate.compareTo(notAfter) > 0);
+        return (checkDate.compareTo(notAfter) > 0);
     }
 
     public boolean isExpireApproaching() throws SSLException, FileNotFoundException, IOException, GeneralSecurityException {
@@ -62,44 +72,49 @@ public class CertificateManager {
         Calendar checkDate = Calendar.getInstance();
         checkDate.setTimeZone(TimeZone.getDefault());
         checkDate.add(Calendar.MONTH, CERT_EXPIRE_CHECK_MONTHES);
-        return(checkDate.compareTo(notAfter) > 0);
+        return (checkDate.compareTo(notAfter) > 0);
     }
 
     public void setSSLSocketFactory(SSLSocketFactory f) {
-      sslSocketFactory = f;
+        sslSocketFactory = f;
     }
 
     public void setAuthURI(String v) {
-      authURI = v;
+        authURI = v;
     }
 
     public String getFileName() {
-      return fileName;
+        return fileName;
     }
 
     public String getPassword() {
-      return password;
+        return password;
     }
 
     public void updateCertificate() throws IOException {
-      URL url = new URL(authURI);
-      URL post_url = new URL(url.getProtocol(), url.getHost(), url.getPort(), "/api/cert", null);
-      logger.info(post_url.toString());
-      ByteArrayOutputStream body = request(post_url.toString(), "POST");
-      JSONObject result = new JSONObject(body.toString("UTF-8"));
-      String get_url = result.getString("uri");
-      String new_password = result.getString("pass");
-      ByteArrayOutputStream cert = request(get_url, "GET");
-      File certDir = new File(new File(new File(System.getProperty("user.home")), ".monsiaj"), "certificates");
-      Date now = new Date();
-      SimpleDateFormat format = new SimpleDateFormat("yyyyMMddHHmmss");
-      File new_cert = new File(certDir, format.format(now) + ".p12");
-      certDir.mkdirs();
-      FileOutputStream fos = new FileOutputStream(new_cert);
-      cert.writeTo(fos);
-      fos.close();
-      fileName = new_cert.getPath();
-      password = new_password;
+        URL url = new URL(authURI);
+        String host = AUTH_HOST_MAP.get(url.getHost());
+        if (host == null) {
+            logger.info("does not support certificate update: " + authURI);
+            return;
+        }
+        URL post_url = new URL(url.getProtocol(), host, url.getPort(), "/api/cert", null);
+        logger.info(post_url.toString());
+        ByteArrayOutputStream body = request(post_url.toString(), "POST");
+        JSONObject result = new JSONObject(body.toString("UTF-8"));
+        String get_url = result.getString("uri");
+        String new_password = result.getString("pass");
+        ByteArrayOutputStream cert = request(get_url, "GET");
+        File certDir = new File(new File(new File(System.getProperty("user.home")), ".monsiaj"), "certificates");
+        Date now = new Date();
+        SimpleDateFormat format = new SimpleDateFormat("yyyyMMddHHmmss");
+        File new_cert = new File(certDir, format.format(now) + ".p12");
+        certDir.mkdirs();
+        FileOutputStream fos = new FileOutputStream(new_cert);
+        cert.writeTo(fos);
+        fos.close();
+        fileName = new_cert.getPath();
+        password = new_password;
     }
 
     private ByteArrayOutputStream request(String uri, String method) throws IOException {
@@ -141,14 +156,14 @@ public class CertificateManager {
 
     public Calendar getNotAfter() throws SSLException, FileNotFoundException, IOException, GeneralSecurityException {
         if (this.notAfter != null) {
-          return this.notAfter;
+            return this.notAfter;
         }
         final KeyStore ks = KeyStore.getInstance("PKCS12");
         final InputStream is = new FileInputStream(fileName);
         ks.load(is, this.password.toCharArray());
         Enumeration<String> en = ks.aliases();
         String alias = en.nextElement();
-        X509Certificate cert = (X509Certificate)ks.getCertificate(alias);
+        X509Certificate cert = (X509Certificate) ks.getCertificate(alias);
         Date d = cert.getNotAfter();
         Calendar result = Calendar.getInstance();
         result.setTime(d);
@@ -158,8 +173,8 @@ public class CertificateManager {
     }
 
     private ByteArrayOutputStream getHTTPBody(HttpURLConnection con) {
-        try (ByteArrayOutputStream bytes = new ByteArrayOutputStream()) {
-            try (BufferedOutputStream bos = new BufferedOutputStream(bytes)) {
+        try ( ByteArrayOutputStream bytes = new ByteArrayOutputStream()) {
+            try ( BufferedOutputStream bos = new BufferedOutputStream(bytes)) {
                 BufferedInputStream bis = new BufferedInputStream(con.getInputStream());
                 int length;
                 while ((length = bis.read()) != -1) {

--- a/src/main/java/org/montsuqi/monsiaj/client/CertificateManager.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/CertificateManager.java
@@ -25,7 +25,7 @@ import org.json.JSONObject;
  */
 public class CertificateManager {
 
-    static final Logger logger = LogManager.getLogger(Protocol.class);
+    static final Logger LOG = LogManager.getLogger(Protocol.class);
     private String authURI = null;
     private SSLSocketFactory sslSocketFactory;
 
@@ -43,7 +43,7 @@ public class CertificateManager {
             put("sms-stg.orca.orcamo.jp", "auth-stg.cmo.orcamo.jp");
             put("sms-stg.glorca.orcamo.jp", "auth-stg.glcmo.orcamo.jp");
             // テスト環境
-            put("sms-test.orca.orcamo.jp", "auth-test.cmo.orcamo.jp");
+            put("sms-test.orca.orcamo.jp", "cmo-auth-test.orca.orcamo.jp");
             // デモ環境
             put("sms.orca-ng.org", "auth.orca-ng.org");
         }
@@ -95,11 +95,11 @@ public class CertificateManager {
         URL url = new URL(authURI);
         String host = AUTH_HOST_MAP.get(url.getHost());
         if (host == null) {
-            logger.info("does not support certificate update: " + authURI);
+            LOG.info("does not support certificate update: " + authURI);
             return;
         }
         URL post_url = new URL(url.getProtocol(), host, url.getPort(), "/api/cert", null);
-        logger.info(post_url.toString());
+        LOG.info(post_url.toString());
         ByteArrayOutputStream body = request(post_url.toString(), "POST");
         JSONObject result = new JSONObject(body.toString("UTF-8"));
         String get_url = result.getString("uri");
@@ -145,7 +145,7 @@ public class CertificateManager {
                 break;
             default:
                 String message = con.getResponseMessage();
-                logger.info("http error: " + resCode + " " + message);
+                LOG.info("http error: " + resCode + " " + message);
                 throw new HttpResponseException(resCode);
         }
 

--- a/src/main/java/org/montsuqi/monsiaj/client/CertificateManager.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/CertificateManager.java
@@ -46,6 +46,18 @@ public class CertificateManager {
             put("sms-test.orca.orcamo.jp", "cmo-auth-test.orca.orcamo.jp");
             // デモ環境
             put("sms.orca-ng.org", "auth.orca-ng.org");
+            // 給管帳運用
+            put("sms.qkn.orcamo.jp", "auth.cmo.orcamo.jp");
+            put("sms.glqkn.orcamo.jp", "auth.glcmo.orcamo.jp");
+            // 給管帳ステージング
+            put("sms-stg.qkn.orcamo.jp", "auth-stg.cmo.orcamo.jp");
+            put("sms-stg.glqkn.orcamo.jp", "auth-stg.glcmo.orcamo.jp");
+            // 医見書運用
+            put("sms.ikn.orcamo.jp", "auth.cmo.orcamo.jp");
+            put("sms.glikn.orcamo.jp", "auth.glcmo.orcamo.jp");
+            // 医見書ステージング
+            put("sms-stg.ikn.orcamo.jp", "auth-stg.cmo.orcamo.jp");
+            put("sms-stg.glikn.orcamo.jp", "auth-stg.glcmo.orcamo.jp");
         }
     };
 
@@ -71,7 +83,13 @@ public class CertificateManager {
         Calendar notAfter = getNotAfter();
         Calendar checkDate = Calendar.getInstance();
         checkDate.setTimeZone(TimeZone.getDefault());
-        checkDate.add(Calendar.MONTH, CERT_EXPIRE_CHECK_MONTHES);
+        int monthes = CERT_EXPIRE_CHECK_MONTHES;
+        String strMonthes = System.getProperty("monsia.cert_expire_check_monthes");
+        if (strMonthes != null) {
+            monthes = Integer.parseInt(strMonthes);
+            if (monthes < 2) monthes = 2;
+        }
+        checkDate.add(Calendar.MONTH, monthes);
         return (checkDate.compareTo(notAfter) > 0);
     }
 

--- a/src/main/java/org/montsuqi/monsiaj/client/CertificateManager.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/CertificateManager.java
@@ -52,12 +52,16 @@ public class CertificateManager {
             // 給管帳ステージング
             put("sms-stg.qkn.orcamo.jp", "auth-stg.cmo.orcamo.jp");
             put("sms-stg.glqkn.orcamo.jp", "auth-stg.glcmo.orcamo.jp");
+            // 給管帳デモ
+            put("sms.qkn.orca-ng.org", "auth.orca-ng.org");
             // 医見書運用
             put("sms.ikn.orcamo.jp", "auth.cmo.orcamo.jp");
             put("sms.glikn.orcamo.jp", "auth.glcmo.orcamo.jp");
             // 医見書ステージング
             put("sms-stg.ikn.orcamo.jp", "auth-stg.cmo.orcamo.jp");
             put("sms-stg.glikn.orcamo.jp", "auth-stg.glcmo.orcamo.jp");
+            // 医見書デモ
+            put("sms.ikn.orca-ng.org", "auth.orca-ng.org");
         }
     };
 
@@ -87,7 +91,9 @@ public class CertificateManager {
         String strMonthes = System.getProperty("monsia.cert_expire_check_monthes");
         if (strMonthes != null) {
             monthes = Integer.parseInt(strMonthes);
-            if (monthes < 2) monthes = 2;
+            if (monthes < 2) {
+                monthes = 2;
+            }
         }
         checkDate.add(Calendar.MONTH, monthes);
         return (checkDate.compareTo(notAfter) > 0);
@@ -111,10 +117,13 @@ public class CertificateManager {
 
     public void updateCertificate() throws IOException {
         URL url = new URL(authURI);
-        String host = AUTH_HOST_MAP.get(url.getHost());
+        String host = System.getProperty("monsia.update_cert_api_host");
         if (host == null) {
-            LOG.info("does not support certificate update: " + authURI);
-            return;
+            host = AUTH_HOST_MAP.get(url.getHost());
+            if (host == null) {
+                LOG.info("does not support certificate update: " + authURI);
+                return;
+            }
         }
         URL post_url = new URL(url.getProtocol(), host, url.getPort(), "/api/cert", null);
         LOG.info(post_url.toString());
@@ -152,6 +161,9 @@ public class CertificateManager {
             con.setDoOutput(true);
             con.setRequestMethod("POST");
             con.setRequestProperty("Content-Type", "application/json");
+            try ( DataOutputStream wr = new DataOutputStream(con.getOutputStream())) {
+                wr.write("{}".getBytes());
+            }
         }
 
         con.connect();

--- a/src/main/java/org/montsuqi/monsiaj/client/Client.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/Client.java
@@ -53,7 +53,7 @@ public class Client {
 
     private boolean isReceiving;
     private final Config conf;
-    private static final Logger logger = LogManager.getLogger(Client.class);
+    private static final Logger LOGGER = LogManager.getLogger(Client.class);
     private Protocol protocol;
     private final UIControl uiControl;
     private static final int DEFAULT_PING_TIMER_PERIOD = 7 * 1000;
@@ -86,7 +86,7 @@ public class Client {
         } else {
             authURI = "http://" + authURI;
         }
-        logger.info("try connect " + authURI);
+        LOGGER.info("try connect " + authURI);
         protocol = new Protocol(authURI, conf.getUser(num), conf.getPassword(num), conf.getUseSSO(num));
         if (conf.getUseSSL(num)) {
             if (conf.getUsePKCS11(num)) {
@@ -123,16 +123,20 @@ public class Client {
                 String title = Messages.getString("Client.update_certificate_confirm_dialog_title");
                 int result = JOptionPane.showConfirmDialog(null, alert, title, JOptionPane.YES_NO_OPTION);
                 if (result == JOptionPane.YES_OPTION) {
-                    cm.setSSLSocketFactory(protocol.getSSLSocketFactory());
-                    cm.setAuthURI(authURI);
-                    cm.updateCertificate();
-                    conf.setClientCertificateFile(num, cm.getFileName());
-                    if (conf.getSaveClientCertificatePassword(num)) {
-                        conf.setClientCertificatePassword(num, cm.getPassword());
+                    try {
+                        cm.setSSLSocketFactory(protocol.getSSLSocketFactory());
+                        cm.setAuthURI(authURI);
+                        cm.updateCertificate();
+                        conf.setClientCertificateFile(num, cm.getFileName());
+                        if (conf.getSaveClientCertificatePassword(num)) {
+                            conf.setClientCertificatePassword(num, cm.getPassword());
+                        }
+                        conf.save();
+                        String message = Messages.getString("Client.success_update_certificate");
+                        JOptionPane.showMessageDialog(uiControl.getTopWindow(), message);
+                    } catch (IOException ex) {
+                        LOGGER.info(ex, ex);
                     }
-                    conf.save();
-                    String message = Messages.getString("Client.success_update_certificate");
-                    JOptionPane.showMessageDialog(uiControl.getTopWindow(), message);
                 }
             }
         }
@@ -143,7 +147,7 @@ public class Client {
             JOptionPane.showMessageDialog(uiControl.getTopWindow(), Messages.getString("Client.openid_connect.login_failure"));
             System.exit(1);
         }
-        logger.info("connected session_id:" + protocol.getSessionId());
+        LOGGER.info("connected session_id:" + protocol.getSessionId());
         startReceiving();
         windowStack = protocol.getWindow();
         updateScreen();
@@ -157,7 +161,7 @@ public class Client {
                 new Thread(pushReceiver).start();
                 new Thread(handler).start();
             } catch (URISyntaxException | KeyStoreException | FileNotFoundException | NoSuchAlgorithmException | CertificateException ex) {
-                logger.info(ex, ex);
+                LOGGER.info(ex, ex);
             }
         }
         startPing();
@@ -175,9 +179,9 @@ public class Client {
         try {
             protocol.endSession();
             pushReceiver.stop();
-            logger.info("disconnect session_id:" + protocol.getSessionId());
+            LOGGER.info("disconnect session_id:" + protocol.getSessionId());
         } catch (IOException | JSONException e) {
-            logger.warn(e, e);
+            LOGGER.warn(e, e);
         } finally {
             System.exit(0);
         }
@@ -203,8 +207,8 @@ public class Client {
         focusedWidget = windowData.getString("focused_widget");
         JSONArray windows = windowData.getJSONArray("windows");
 
-        logger.info("----");
-        logger.info("focused_window[" + focusedWindow + "]");
+        LOGGER.info("----");
+        LOGGER.info("focused_window[" + focusedWindow + "]");
 
         for (int i = 0; i < windows.length(); i++) {
             JSONObject w = windows.getJSONObject(i);
@@ -216,12 +220,12 @@ public class Client {
                 try {
                     node = new Node(Interface.parseInput(new ByteArrayInputStream(gladeData.getBytes("UTF-8")), uiControl), windowName);
                 } catch (UnsupportedEncodingException ex) {
-                    logger.info(ex, ex);
+                    LOGGER.info(ex, ex);
                     return;
                 }
                 uiControl.putNode(windowName, node);
             }
-            logger.info("show window[" + windowName + "] put_type[" + putType + "]");
+            LOGGER.info("show window[" + windowName + "] put_type[" + putType + "]");
         }
 
         for (int i = 0; i < windows.length(); i++) {
@@ -284,7 +288,7 @@ public class Client {
                 JSONObject params = new JSONObject();
                 params.put("event_data", eventData);
 
-                logger.info("window:" + windowName + " widget:" + widgetName + " event:" + event);
+                LOGGER.info("window:" + windowName + " widget:" + widgetName + " event:" + event);
 
                 long t2 = System.currentTimeMillis();
 
@@ -305,7 +309,7 @@ public class Client {
                 msg += "server_total:" + total_exec_time + "ms ";
                 msg += "server_app:" + app_exec_time + "ms ";
                 msg += "update_screen:" + (t4 - t3) + "ms";
-                logger.info(msg);
+                LOGGER.info(msg);
             }
         } catch (JSONException | IOException ex) {
             ExceptionDialog.showExceptionDialog(ex);
@@ -315,7 +319,7 @@ public class Client {
 
     private void listDownloads() throws IOException, JSONException {
         JSONArray array = protocol.listDownloads();
-        logger.debug(array);
+        LOGGER.debug(array);
         for (int j = 0; j < array.length(); j++) {
             JSONObject item = array.getJSONObject(j);
 
@@ -364,7 +368,7 @@ public class Client {
         try {
             if (!isReceiving()) {
                 startReceiving();
-                logger.debug("sendPing");
+                LOGGER.debug("sendPing");
                 if (!protocol.enablePushClient()) {
                     listDownloads();
                 }
@@ -374,7 +378,7 @@ public class Client {
                 stopReceiving();
             }
         } catch (IOException | JSONException ex) {
-            logger.catching(Level.FATAL, ex);
+            LOGGER.catching(Level.FATAL, ex);
             ExceptionDialog.showExceptionDialog(ex);
             System.exit(1);
         }

--- a/src/main/java/org/montsuqi/monsiaj/client/Client.java
+++ b/src/main/java/org/montsuqi/monsiaj/client/Client.java
@@ -110,25 +110,25 @@ public class Client {
             conf.save();
         }
         if (conf.getUseSSL(num)) {
-            CertificateManager cert = new CertificateManager(conf.getClientCertificateFile(num), conf.getClientCertificatePassword(num));
-            if (cert.isExpire()) {
+            CertificateManager cm = new CertificateManager(conf.getClientCertificateFile(num), conf.getClientCertificatePassword(num));
+            if (cm.isExpire()) {
                 String message = Messages.getString("Client.expire_certificate");
                 JOptionPane.showMessageDialog(uiControl.getTopWindow(), message);
                 System.exit(1);
             }
-            if (cert.isExpireApproaching()) {
-                Calendar notAfter = cert.getNotAfter();
+            if (cm.isExpireApproaching()) {
+                Calendar notAfter = cm.getNotAfter();
                 String format = Messages.getString("Client.certificate_expiration_is_approaching");
                 String alert = String.format(format, notAfter, notAfter, notAfter, notAfter, notAfter, notAfter, notAfter);
                 String title = Messages.getString("Client.update_certificate_confirm_dialog_title");
                 int result = JOptionPane.showConfirmDialog(null, alert, title, JOptionPane.YES_NO_OPTION);
                 if (result == JOptionPane.YES_OPTION) {
-                    cert.setSSLSocketFactory(protocol.getSSLSocketFactory());
-                    cert.setAuthURI(authURI);
-                    cert.updateCertificate();
-                    conf.setClientCertificateFile(num, cert.getFileName());
+                    cm.setSSLSocketFactory(protocol.getSSLSocketFactory());
+                    cm.setAuthURI(authURI);
+                    cm.updateCertificate();
+                    conf.setClientCertificateFile(num, cm.getFileName());
                     if (conf.getSaveClientCertificatePassword(num)) {
-                        conf.setClientCertificatePassword(num, cert.getPassword());
+                        conf.setClientCertificatePassword(num, cm.getPassword());
                     }
                     conf.save();
                     String message = Messages.getString("Client.success_update_certificate");


### PR DESCRIPTION
* サーバURLで証明書更新API(共通基盤)のホストを変更するよう修正
* WAFのPOSTメソッドの制限のために、POSTの場合にダミーBodyを設定
* 証明書更新に失敗してもエラーで終了とせずにクライアント接続を行なう