### PR TITLE
ラベルプリンタ用紙など一般的でない用紙の印刷ができなかった

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.montsuqi.monsiaj</groupId>
     <artifactId>monsiaj</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.25</version>
+    <version>2.0.26</version>
     <name>monsiaj</name>
     <url>https://github.com/montsuqi/monsiaj</url>
     <description>montsuqi panda client for java</description>

--- a/src/main/java/org/montsuqi/monsiaj/util/PDFPrint.java
+++ b/src/main/java/org/montsuqi/monsiaj/util/PDFPrint.java
@@ -59,8 +59,6 @@ public class PDFPrint {
     public static void print(File file) {
         try {
             try ( PDDocument document = PDDocument.load(file)) {
-                MediaSizeName size = getMediaSizeName(document);
-
                 PrinterJob job = PrinterJob.getPrinterJob();
                 job.setPageable(new PDFPageable(document));
                 PrintService ps = loadPrintService();
@@ -70,7 +68,10 @@ public class PDFPrint {
                 PrintRequestAttributeSet attr = loadPrintRequestAttributeSet();
                 if (attr == null) {
                     attr = new HashPrintRequestAttributeSet();
-                    attr.add(size);
+                    MediaSizeName msn = getMediaSizeName(document);
+                    if (msn != null) {
+                        attr.add(msn);
+                    }
                 }
                 attr.add(new JobName(file.getName(), null));
 

--- a/src/main/java/org/montsuqi/monsiaj/util/PDFPrint.java
+++ b/src/main/java/org/montsuqi/monsiaj/util/PDFPrint.java
@@ -1,5 +1,6 @@
 package org.montsuqi.monsiaj.util;
 
+import java.awt.geom.Rectangle2D;
 import java.awt.print.*;
 import java.io.File;
 import java.io.*;
@@ -14,6 +15,7 @@ import javax.print.attribute.PrintRequestAttributeSet;
 import javax.print.attribute.Size2DSyntax;
 import javax.print.attribute.standard.Copies;
 import javax.print.attribute.standard.JobName;
+import javax.print.attribute.standard.MediaPrintableArea;
 import javax.print.attribute.standard.MediaSize;
 import javax.print.attribute.standard.MediaSizeName;
 import org.apache.logging.log4j.LogManager;
@@ -24,19 +26,24 @@ import org.apache.pdfbox.rendering.PDFRenderer;
 import org.montsuqi.monsiaj.client.PrinterConfig;
 
 public class PDFPrint {
+
     private static final Logger LOG = LogManager.getLogger(PDFPrint.class);
     private static final Preferences PREFS = Preferences.userNodeForPackage(PDFPrint.class);
 
     public static void print(File file, int copies, PrintService ps) {
         LOG.debug("print start - " + file);
         try {
-            try (PDDocument document = PDDocument.load(file)) {
-                MediaSizeName size = getMediaSizeName(document);
+            try ( PDDocument doc = PDDocument.load(file)) {
+                MediaSizeName msn = getMediaSizeName(doc);
                 PrinterJob job = PrinterJob.getPrinterJob();
                 job.setPrintService(ps);
-                job.setPageable(new PDFPageable(document));
+                job.setPageable(new PDFPageable(doc));
                 PrintRequestAttributeSet attr = new HashPrintRequestAttributeSet();
-                attr.add(size);
+                if (msn != null) {
+                    attr.add(msn);
+                } else {
+                    attr.add(getMediaPrintableArea(doc));
+                }
                 attr.add(new Copies(copies));
                 attr.add(new JobName(file.getName(), null));
                 PageFormat pf = job.getPageFormat(attr);
@@ -53,19 +60,19 @@ public class PDFPrint {
 
     public static void print(File file) {
         try {
-            try (PDDocument document = PDDocument.load(file)) {
+            try ( PDDocument document = PDDocument.load(file)) {
                 MediaSizeName size = getMediaSizeName(document);
 
                 PrinterJob job = PrinterJob.getPrinterJob();
                 job.setPageable(new PDFPageable(document));
                 PrintService ps = loadPrintService();
                 if (ps != null) {
-                  job.setPrintService(ps);
+                    job.setPrintService(ps);
                 }
                 PrintRequestAttributeSet attr = loadPrintRequestAttributeSet();
                 if (attr == null) {
-                  attr = new HashPrintRequestAttributeSet();
-                  attr.add(size);
+                    attr = new HashPrintRequestAttributeSet();
+                    attr.add(size);
                 }
                 attr.add(new JobName(file.getName(), null));
 
@@ -87,44 +94,44 @@ public class PDFPrint {
     }
 
     public static PrintService loadPrintService() {
-      return PrinterConfig.getPrintService(PREFS.get("printService",""));
+        return PrinterConfig.getPrintService(PREFS.get("printService", ""));
     }
 
     public static void savePrintService(PrintService ps) {
-      PREFS.put("printService",ps.getName());
+        PREFS.put("printService", ps.getName());
     }
 
     public static PrintRequestAttributeSet loadPrintRequestAttributeSet() {
-      try {
-        byte[] array = PREFS.getByteArray("printRequestAttributeSet",new byte[0]);
-        ByteArrayInputStream bais = new ByteArrayInputStream(array);
-        PrintRequestAttributeSet attr;
-          try (ObjectInputStream ois = new ObjectInputStream(bais)) {
-              attr = (PrintRequestAttributeSet)ois.readObject();
-          }
-        return attr;
-      } catch (IOException |ClassNotFoundException ex) {
-        LOG.warn("can not load printRequestAttributeSet");
-        LOG.debug(ex, ex);
-      }
-      return null;
+        try {
+            byte[] array = PREFS.getByteArray("printRequestAttributeSet", new byte[0]);
+            ByteArrayInputStream bais = new ByteArrayInputStream(array);
+            PrintRequestAttributeSet attr;
+            try ( ObjectInputStream ois = new ObjectInputStream(bais)) {
+                attr = (PrintRequestAttributeSet) ois.readObject();
+            }
+            return attr;
+        } catch (IOException | ClassNotFoundException ex) {
+            LOG.warn("can not load printRequestAttributeSet");
+            LOG.debug(ex, ex);
+        }
+        return null;
     }
 
     public static void savePrintRequestAttributeSet(PrintRequestAttributeSet attr) {
-      try {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-          try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
-              oos.writeObject(attr);
-              oos.flush();
-          }
-        PREFS.putByteArray("printRequestAttributeSet",baos.toByteArray());
-      } catch (IOException ex) {
-        LOG.warn(ex, ex);
-      }
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try ( ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+                oos.writeObject(attr);
+                oos.flush();
+            }
+            PREFS.putByteArray("printRequestAttributeSet", baos.toByteArray());
+        } catch (IOException ex) {
+            LOG.warn(ex, ex);
+        }
     }
 
-    public static MediaSizeName getMediaSizeName(PDDocument document) throws IOException {
-        PDFRenderer renderer = new PDFRenderer(document);
+    public static Rectangle2D.Float getDocumentSize(PDDocument doc) throws IOException {
+        PDFRenderer renderer = new PDFRenderer(doc);
         BufferedImage image = renderer.renderImageWithDPI(0, 72f);
         float w, h, swp;
         w = image.getWidth() / 72f;
@@ -134,7 +141,17 @@ public class PDFPrint {
             w = h;
             h = swp;
         }
-        return MediaSize.findMedia(w, h, Size2DSyntax.INCH);
+        return new Rectangle2D.Float(0, 0, w, h);
+    }
+
+    public static MediaSizeName getMediaSizeName(PDDocument doc) throws IOException {
+        Rectangle2D.Float rect = getDocumentSize(doc);
+        return MediaSize.findMedia(rect.width, rect.height, Size2DSyntax.INCH);
+    }
+
+    public static MediaPrintableArea getMediaPrintableArea(PDDocument doc) throws IOException {
+        Rectangle2D.Float rect = getDocumentSize(doc);
+        return new MediaPrintableArea(0, 0, rect.width, rect.height, Size2DSyntax.INCH);
     }
 
     public static void main(String args[]) throws Exception {
@@ -152,7 +169,7 @@ public class PDFPrint {
             if (ps == null) {
                 PDFPrint.print(new File(args[1]));
             } else {
-                PDFPrint.print(new File(args[1]),1,ps);
+                PDFPrint.print(new File(args[1]), 1, ps);
             }
         }
     }

--- a/src/main/java/org/montsuqi/monsiaj/util/PDFPrint.java
+++ b/src/main/java/org/montsuqi/monsiaj/util/PDFPrint.java
@@ -24,15 +24,14 @@ import org.apache.pdfbox.rendering.PDFRenderer;
 import org.montsuqi.monsiaj.client.PrinterConfig;
 
 public class PDFPrint {
-    private static final Logger logger = LogManager.getLogger(PDFPrint.class);
-    private static final Preferences prefs = Preferences.userNodeForPackage(PDFPrint.class);
+    private static final Logger LOG = LogManager.getLogger(PDFPrint.class);
+    private static final Preferences PREFS = Preferences.userNodeForPackage(PDFPrint.class);
 
     public static void print(File file, int copies, PrintService ps) {
-        logger.debug("print start - " + file);
+        LOG.debug("print start - " + file);
         try {
             try (PDDocument document = PDDocument.load(file)) {
                 MediaSizeName size = getMediaSizeName(document);
-                
                 PrinterJob job = PrinterJob.getPrinterJob();
                 job.setPrintService(ps);
                 job.setPageable(new PDFPageable(document));
@@ -40,25 +39,23 @@ public class PDFPrint {
                 attr.add(size);
                 attr.add(new Copies(copies));
                 attr.add(new JobName(file.getName(), null));
-                
                 PageFormat pf = job.getPageFormat(attr);
                 Paper paper = pf.getPaper();
                 paper.setImageableArea(0, 0, paper.getWidth(), paper.getHeight());
                 pf.setPaper(paper);
-                
                 job.print(attr);
             }
         } catch (IOException | PrinterException ex) {
-            logger.warn(ex, ex);
+            LOG.warn(ex, ex);
         }
-        logger.debug("print end - " + file);
+        LOG.debug("print end - " + file);
     }
 
     public static void print(File file) {
         try {
             try (PDDocument document = PDDocument.load(file)) {
                 MediaSizeName size = getMediaSizeName(document);
-                
+
                 PrinterJob job = PrinterJob.getPrinterJob();
                 job.setPageable(new PDFPageable(document));
                 PrintService ps = loadPrintService();
@@ -71,7 +68,7 @@ public class PDFPrint {
                   attr.add(size);
                 }
                 attr.add(new JobName(file.getName(), null));
-                
+
                 if (!job.printDialog(attr)) {
                     return;
                 }
@@ -79,27 +76,27 @@ public class PDFPrint {
                 Paper paper = pf.getPaper();
                 paper.setImageableArea(0, 0, paper.getWidth(), paper.getHeight());
                 pf.setPaper(paper);
-                
+
                 job.print(attr);
                 savePrintService(job.getPrintService());
                 savePrintRequestAttributeSet(attr);
             }
         } catch (IOException | PrinterException ex) {
-            logger.warn(ex, ex);
+            LOG.warn(ex, ex);
         }
     }
 
     public static PrintService loadPrintService() {
-      return PrinterConfig.getPrintService(prefs.get("printService",""));
+      return PrinterConfig.getPrintService(PREFS.get("printService",""));
     }
 
     public static void savePrintService(PrintService ps) {
-      prefs.put("printService",ps.getName());
+      PREFS.put("printService",ps.getName());
     }
 
     public static PrintRequestAttributeSet loadPrintRequestAttributeSet() {
       try {
-        byte[] array = prefs.getByteArray("printRequestAttributeSet",new byte[0]);
+        byte[] array = PREFS.getByteArray("printRequestAttributeSet",new byte[0]);
         ByteArrayInputStream bais = new ByteArrayInputStream(array);
         PrintRequestAttributeSet attr;
           try (ObjectInputStream ois = new ObjectInputStream(bais)) {
@@ -107,8 +104,8 @@ public class PDFPrint {
           }
         return attr;
       } catch (IOException |ClassNotFoundException ex) {
-        logger.warn("can not load printRequestAttributeSet");
-        logger.debug(ex, ex);
+        LOG.warn("can not load printRequestAttributeSet");
+        LOG.debug(ex, ex);
       }
       return null;
     }
@@ -120,9 +117,9 @@ public class PDFPrint {
               oos.writeObject(attr);
               oos.flush();
           }
-        prefs.putByteArray("printRequestAttributeSet",baos.toByteArray());
+        PREFS.putByteArray("printRequestAttributeSet",baos.toByteArray());
       } catch (IOException ex) {
-        logger.warn(ex, ex);
+        LOG.warn(ex, ex);
       }
     }
 

--- a/src/main/java/org/montsuqi/monsiaj/util/PDFPrint.java
+++ b/src/main/java/org/montsuqi/monsiaj/util/PDFPrint.java
@@ -41,8 +41,6 @@ public class PDFPrint {
                 PrintRequestAttributeSet attr = new HashPrintRequestAttributeSet();
                 if (msn != null) {
                     attr.add(msn);
-                } else {
-                    attr.add(getMediaPrintableArea(doc));
                 }
                 attr.add(new Copies(copies));
                 attr.add(new JobName(file.getName(), null));
@@ -130,7 +128,7 @@ public class PDFPrint {
         }
     }
 
-    public static Rectangle2D.Float getDocumentSize(PDDocument doc) throws IOException {
+    public static MediaSizeName getMediaSizeName(PDDocument doc) throws IOException {
         PDFRenderer renderer = new PDFRenderer(doc);
         BufferedImage image = renderer.renderImageWithDPI(0, 72f);
         float w, h, swp;
@@ -141,17 +139,7 @@ public class PDFPrint {
             w = h;
             h = swp;
         }
-        return new Rectangle2D.Float(0, 0, w, h);
-    }
-
-    public static MediaSizeName getMediaSizeName(PDDocument doc) throws IOException {
-        Rectangle2D.Float rect = getDocumentSize(doc);
-        return MediaSize.findMedia(rect.width, rect.height, Size2DSyntax.INCH);
-    }
-
-    public static MediaPrintableArea getMediaPrintableArea(PDDocument doc) throws IOException {
-        Rectangle2D.Float rect = getDocumentSize(doc);
-        return new MediaPrintableArea(0, 0, rect.width, rect.height, Size2DSyntax.INCH);
+        return MediaSize.findMedia(w, h, Size2DSyntax.INCH);
     }
 
     public static void main(String args[]) throws Exception {


### PR DESCRIPTION
* 一般サイズでない場合に mediaSizeName = null を指定していたのが問題だった
    * mediaSizeNameを指定しなければ適切に印刷してくれる(プリンタによるかもだが
    * PDFライブラリpdfboxへの切替時に入ったバグ(用紙サイズ指定部分を以前の実装と同等に戻した)