### PR TITLE
NumberDocumentの親クラスをLengthLimitableDocumentに変更

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.montsuqi.monsiaj</groupId>
     <artifactId>monsiaj</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.28</version>
+    <version>2.0.29</version>
     <name>monsiaj</name>
     <url>https://github.com/montsuqi/monsiaj</url>
     <description>montsuqi panda client for java</description>

--- a/src/main/java/org/montsuqi/monsiaj/widgets/NumberEntry.java
+++ b/src/main/java/org/montsuqi/monsiaj/widgets/NumberEntry.java
@@ -168,7 +168,7 @@ public class NumberEntry extends Entry {
     }
 }
 
-class NumberDocument extends PlainDocument {
+class NumberDocument extends LengthLimitableDocument {
 
     private String originalFormat;
     private NumberFormat format;
@@ -209,10 +209,6 @@ class NumberDocument extends PlainDocument {
         PrecisionScale ps = new PrecisionScale(originalFormat);
         value = value.setScale(ps.precision, ps.scale);
         return value;
-    }
-
-    public void setLimit(int limit) {
-        // text_max_length、max_lengthプロパティに対応
     }
 
     void setFormat(String format) {

--- a/src/main/java/org/montsuqi/monsiaj/widgets/NumberEntry.java
+++ b/src/main/java/org/montsuqi/monsiaj/widgets/NumberEntry.java
@@ -123,9 +123,9 @@ public class NumberEntry extends Entry {
     }
 
     public static void main(String[] args) {
-        final JFrame f = new JFrame("TestNumberEntry"); 
+        final JFrame f = new JFrame("TestNumberEntry");
         final NumberEntry ne = new NumberEntry();
-        ne.setFormat("-----"); 
+        ne.setFormat("-----");
         ne.setValue(new BigDecimal(0));
         f.getContentPane().setLayout(new BorderLayout());
         f.getContentPane().add(ne, BorderLayout.CENTER);
@@ -157,8 +157,8 @@ public class NumberEntry extends Entry {
             case KeyEvent.VK_HOME: // fall through
             case KeyEvent.VK_END:
                 if (e.getID() == KeyEvent.KEY_PRESSED || e.getID() == KeyEvent.KEY_RELEASED) {
-                setValue(NumberDocument.ZERO);
-            }
+                    setValue(NumberDocument.ZERO);
+                }
                 e.consume();
                 break;
             default:
@@ -176,7 +176,7 @@ class NumberDocument extends PlainDocument {
     private int scale;
     private int expo;
     private boolean minus = false;
-    protected static final String DEFAULT_FORMAT = "ZZZZZZZZZ9"; 
+    protected static final String DEFAULT_FORMAT = "ZZZZZZZZZ9";
     static final BigDecimal ZERO = new BigDecimal(BigInteger.ZERO);
     static final BigDecimal ONE = new BigDecimal(BigInteger.ONE);
     protected static final Logger logger = LogManager.getLogger(NumberDocument.class);
@@ -209,6 +209,10 @@ class NumberDocument extends PlainDocument {
         PrecisionScale ps = new PrecisionScale(originalFormat);
         value = value.setScale(ps.precision, ps.scale);
         return value;
+    }
+
+    public void setLimit(int limit) {
+        // text_max_length、max_lengthプロパティに対応
     }
 
     void setFormat(String format) {
@@ -313,7 +317,7 @@ class NumberDocument extends PlainDocument {
         String formatted = formatValue(value);
         remove(0, getLength());
         // treat zero value representation specially
-        if ((formatted.trim().equals("0") || formatted.trim().equals("+0")) && leaveZeroAsBlank()) { 
+        if ((formatted.trim().equals("0") || formatted.trim().equals("+0")) && leaveZeroAsBlank()) {
             // do nothing
         } else {
             super.insertString(0, formatted, a);


### PR DESCRIPTION
* 日レセ2月パッチでNumberEntryウィジェットにtext_max_lengthプロパティが設定された画面定義体が追加された
* text_max_lengthプロパティはEntry.classに適用され、EntryがもつLengthLimitableDocumentオブジェクトにsetLimit()を実行する
* NumberEntryはEntryの子クラスだがDocumentはPlainDocumentベースのNumberDocumentに変更している
    * NumberDocumentはsetLimit()を持たないため、text_max_lengthプロパティ適用時にエラーとなる(ウィジェットひょうじされない) 
    *  NumberDocumentの親クラスをPlainDocumentからLengthLimitableDocument(PlainDocumentベース)に変更する

* 2月パッチ適用の日レセでtext_max_lengthが指定されたNumberEntryが正常動作することを確認